### PR TITLE
downgrading spring version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -28,7 +28,7 @@
 		<axon.version>2.0</axon.version>
 		<testng.version>6.7</testng.version>
 		<com.fasterxml.jackson.version>2.0.2</com.fasterxml.jackson.version>
-		<org.springframework.version>3.2.2.RELEASE</org.springframework.version>
+		<org.springframework.version>3.1.4.RELEASE</org.springframework.version>
 		<junit.version>4.10</junit.version>
 		<org.slf4j.version>1.7.1</org.slf4j.version>
 		<mockito.version>1.9.5</mockito.version>


### PR DESCRIPTION
The platform depends on spring 3.1.4, we can not upgrade it to 3.2.2 due to dependencies to viadeo-configuration etc, so downgrading kasper-fwks spring version 3.1.4 solves the pb.
