### PR TITLE
Feature/exception handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,14 +107,14 @@ subprojects {
       JACKSON_CORE          : 'com.fasterxml.jackson.core:jackson-core:2.1.4',
       JACKSON_JSON          : 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.1.2',
       JACKSON_GUAVA_TYPES   : 'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.1.2',
-      
+
       JERSEY_SERVER         : 'com.sun.jersey:jersey-server:1.16',
       JERSEY_CLIENT         : 'com.sun.jersey:jersey-client:1.16',
       JERSEY_CORE           : 'com.sun.jersey:jersey-core:1.16',
       JERSEY_SERVLET        : 'com.sun.jersey:jersey-servlet:1.16',
       JERSEY_TEST_CORE      : 'com.sun.jersey.jersey-test-framework:jersey-test-framework-core:1.16',
       JERSEY_TEST_HTTP      : 'com.sun.jersey.jersey-test-framework:jersey-test-framework-http:1.16',
-      
+
       PARANAMER             : 'com.thoughtworks.paranamer:paranamer:2.5.2',
       REFLECTIONS           : 'org.reflections:reflections:0.9.8',
       MYSQL                 : 'mysql:mysql-connector-java:5.1.24',
@@ -141,7 +141,7 @@ subprojects {
       GUAVA                 : 'com.google.guava:guava:13.0.1'
 
   ] // see http://stackoverflow.com/questions/9547170/in-gradle-how-do-i-declare-common-dependencies-in-a-single-place
-  
+
   dependencies {
     compile libraries.GUAVA
     compile libraries.JODA_TIME
@@ -166,5 +166,5 @@ buildscript {
         classpath "net.saliman:gradle-cobertura-plugin:1.1.2"
     }
 }
-   
+
 

--- a/kasper-core/src/main/java/com/viadeo/kasper/cqrs/query/IQueryGateway.java
+++ b/kasper-core/src/main/java/com/viadeo/kasper/cqrs/query/IQueryGateway.java
@@ -7,7 +7,6 @@
 package com.viadeo.kasper.cqrs.query;
 
 import com.viadeo.kasper.context.IContext;
-import com.viadeo.kasper.cqrs.query.exceptions.KasperQueryException;
 
 /** The Kasper query gateway, used to answer queries from the kasper platform */
 public interface IQueryGateway {
@@ -17,6 +16,6 @@ public interface IQueryGateway {
 	 * @param query the query to be answered
 	 * @return the Data Transfer Object as an answer
 	 */
-	<Q extends IQuery, DTO extends IQueryDTO> DTO retrieve(IContext context, Q query) throws KasperQueryException;
+	<Q extends IQuery, DTO extends IQueryDTO> DTO retrieve(IContext context, Q query) throws Exception;
 
 }

--- a/kasper-core/src/main/java/com/viadeo/kasper/cqrs/query/IQueryService.java
+++ b/kasper-core/src/main/java/com/viadeo/kasper/cqrs/query/IQueryService.java
@@ -7,14 +7,12 @@
 
 package com.viadeo.kasper.cqrs.query;
 
-import com.viadeo.kasper.cqrs.query.exceptions.KasperQueryException;
-
 /**
  * A Kasper query service
- * 
+ *
  * @param <Q> the associated Query
  * @param <DTO> the associated Data Transfer Object
- * 
+ *
  * @see IQueryDTO
  * @see IQuery
  */
@@ -33,10 +31,10 @@ public interface IQueryService<Q extends IQuery, DTO extends IQueryDTO> {
 	/**
 	 * Operates the service, retrieve a service DTO satisfying the submitted
 	 * filter
-	 * 
+	 *
 	 * @param message a query message
 	 * @return a filled DTO
 	 */
-	DTO retrieve(IQueryMessage<Q> message) throws KasperQueryException;
+	DTO retrieve(IQueryMessage<Q> message) throws Exception;
 
 }

--- a/kasper-core/src/main/java/com/viadeo/kasper/cqrs/query/impl/QueryGatewayBase.java
+++ b/kasper-core/src/main/java/com/viadeo/kasper/cqrs/query/impl/QueryGatewayBase.java
@@ -27,8 +27,8 @@ public class QueryGatewayBase implements IQueryGateway {
 	// -----------------------------------------------------------------------
 
 	@Override
-	public <Q extends IQuery, DTO extends IQueryDTO> DTO retrieve(final IContext context, final Q query) 
-			throws KasperQueryException {
+	public <Q extends IQuery, DTO extends IQueryDTO> DTO retrieve(final IContext context, final Q query)
+			throws Exception {
 		checkNotNull(context);
 		checkNotNull(query);
 
@@ -47,9 +47,18 @@ public class QueryGatewayBase implements IQueryGateway {
 		@SuppressWarnings({"rawtypes", "unchecked"}) // Safe
 		final IQueryMessage message = new QueryMessage(context, query);
 
-		@SuppressWarnings("unchecked") // Caller must ensure
-        final DTO dto = (DTO) service.get().retrieve(message);
-		return dto;
+		//@SuppressWarnings("unchecked") // Caller must ensure
+        try {
+            final DTO dto = (DTO) service.get().retrieve(message);
+    		return dto;
+        }
+        catch (Exception e) {
+            if (e instanceof KasperQueryException)
+                throw e;
+            else
+                throw new KasperQueryException(e.getMessage(), e);
+        }
+
 	}
 
 	// -----------------------------------------------------------------------

--- a/kasper-test/src/test/java/com/viadeo/kasper/cqrs/query/FilteredQueryTest.java
+++ b/kasper-test/src/test/java/com/viadeo/kasper/cqrs/query/FilteredQueryTest.java
@@ -4,7 +4,6 @@ import com.viadeo.kasper.AbstractPlatformTests;
 import com.viadeo.kasper.IDomain;
 import com.viadeo.kasper.context.IContext;
 import com.viadeo.kasper.cqrs.query.annotation.XKasperQueryService;
-import com.viadeo.kasper.cqrs.query.exceptions.KasperQueryException;
 import com.viadeo.kasper.cqrs.query.filter.IQueryDQO;
 import com.viadeo.kasper.cqrs.query.filter.IQueryFilter;
 import com.viadeo.kasper.cqrs.query.filter.impl.AbstractQueryDQO;
@@ -44,7 +43,7 @@ public class FilteredQueryTest extends AbstractPlatformTests {
 			return "test";
 		}
 	}
-	
+
 	// "*Field" classes are public (so there is no gain in testing accessibility here)
 	public static final class TestField<DQO extends IQueryDQO<DQO>>
 			extends BaseQueryField<String, DQO> {}
@@ -78,9 +77,9 @@ public class FilteredQueryTest extends AbstractPlatformTests {
 	// ------------------------------------------------------------------------
 
 	@Test
-	public void test() throws KasperQueryException {
+	public void test() throws Exception {
 
-		// Given 
+		// Given
 		final TestQuery query = new TestQuery();
 		final TestDQO dqo = query.dqo();
 


### PR DESCRIPTION
- receive() now Throws Exception instead of KasperQueryException
- Framework wrap this Exception to a KasperQueryException (except if root exception is a KasperQueryException)
