### PR TITLE
bugfix concurrent modification exception for queryParser.names()

### DIFF
--- a/kasper-common/src/main/java/com/viadeo/kasper/query/exposition/QueryParser.java
+++ b/kasper-common/src/main/java/com/viadeo/kasper/query/exposition/QueryParser.java
@@ -8,6 +8,8 @@ package com.viadeo.kasper.query.exposition;
 
 import java.util.*;
 
+import com.google.common.collect.ImmutableSet;
+
 public class QueryParser implements Iterable<QueryParser> {
 
     private class Scope {
@@ -60,7 +62,7 @@ public class QueryParser implements Iterable<QueryParser> {
     }
 
     public Set<String> names() {
-        return queryMap.keySet();
+        return ImmutableSet.copyOf(queryMap.keySet());
     }
 
     public String name() {

--- a/kasper-common/src/test/java/com/viadeo/kasper/query/exposition/QueryParserTest.java
+++ b/kasper-common/src/test/java/com/viadeo/kasper/query/exposition/QueryParserTest.java
@@ -17,6 +17,21 @@ import java.util.NoSuchElementException;
 import static org.junit.Assert.*;
 
 public class QueryParserTest {
+    
+    @Test public void testConcurrentModificationOfNames() {
+        final QueryParser parser = new QueryParser(ImmutableMap.of("key_1", Arrays.asList("a", "b"), "key_2", Arrays.asList("a", "b"), "key2", Arrays.asList("1")));
+
+        for (String name : parser.names()) {
+            if (name.startsWith("key_")) {
+                for (QueryParser next : parser.begin(name)) {
+                    next.value();
+                }
+                parser.end();
+            }
+        }
+        
+        parser.begin("key2").end();
+    }
 
     @Test
     public void testExists() {


### PR DESCRIPTION
Looks like I have lost this bugfix during a previous PR, resubmitting it :)
