### PR TITLE
Thrown an KasperException when we have an unexpected spring circular reference

### DIFF
--- a/kasper-core/src/main/java/com/viadeo/kasper/core/boot/AnnotationRootProcessor.java
+++ b/kasper-core/src/main/java/com/viadeo/kasper/core/boot/AnnotationRootProcessor.java
@@ -20,6 +20,7 @@ import org.reflections.util.ConfigurationBuilder;
 import org.reflections.util.FilterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanCurrentlyInCreationException;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
@@ -276,7 +277,8 @@ public class AnnotationRootProcessor {
                                     // PROCESSOR DELEGATION
                                     processor.process(clazz);
 
-
+                                } catch (BeanCurrentlyInCreationException e) {
+                                    throw new KasperException(String.format("Unable to process component : %s", clazz), e);
                                 } catch (Exception e) {
                                     LOGGER.warn("Unexpected error during processor delegation, <class=" + clazz.getName() + ">: ", e);
                                 }


### PR DESCRIPTION
The platform should not be able to start with this type of error!
