### PR TITLE
KasperEventBus fixing UnitOfWork transactions

### DIFF
--- a/kasper-platform/src/main/java/com/viadeo/kasper/client/platform/components/eventbus/KasperEventBus.java
+++ b/kasper-platform/src/main/java/com/viadeo/kasper/client/platform/components/eventbus/KasperEventBus.java
@@ -17,6 +17,7 @@ import org.axonframework.domain.EventMessage;
 import org.axonframework.domain.GenericEventMessage;
 import org.axonframework.eventhandling.*;
 import org.axonframework.eventhandling.async.*;
+import org.axonframework.unitofwork.CurrentUnitOfWork;
 import org.axonframework.unitofwork.DefaultUnitOfWorkFactory;
 import org.axonframework.unitofwork.NoTransactionManager;
 import org.slf4j.Logger;
@@ -183,7 +184,11 @@ public class KasperEventBus extends ClusteringEventBus {
 
         final GenericEventMessage<Event> eventMessageAxon = new GenericEventMessage<>(event, metaData);
 
-        this.publish(eventMessageAxon);
+        try {
+            CurrentUnitOfWork.get().publishEvent(eventMessageAxon, this);
+        } catch (IllegalStateException ise) {
+            publish(eventMessageAxon);
+        }
     }
 
     /*


### PR DESCRIPTION
Until now, kaspereventbus was breaking the transactionnal aspect of events published when a unitofwork was started. This PR proposes to:
- If a UOW is started, publish the events only when the UOW is commited.
- If no UOW - meaning the events is being published from a event listener or a query (huh?) - then keep actual behaviour => directly publish the event.

**Note**: I hate the try catch block to determine if a UOW is started, but I couldn't find any other way of guessing if there is a UOW...
