### PR TITLE
bugfix: KasperClient with base location without trailing slash was remov...

### DIFF
--- a/kasper-client/src/main/java/com/viadeo/kasper/client/KasperClient.java
+++ b/kasper-client/src/main/java/com/viadeo/kasper/client/KasperClient.java
@@ -111,9 +111,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class KasperClient {
     private static final KasperClient DEFAULT_KASPER_CLIENT = new KasperClientBuilder().create();
 
-    private final Client client;
-    private final URL commandBaseLocation;
-    private final URL queryBaseLocation;
+    protected final Client client;
+    protected final URL commandBaseLocation;
+    protected final URL queryBaseLocation;
 
     private final Flags flags;
 
@@ -504,12 +504,12 @@ public class KasperClient {
     // RESOLVERS
     // ------------------------------------------------------------------------
 
-    private URI resolveCommandPath(final Class<? extends Command> commandClass) {
+    protected URI resolveCommandPath(final Class<? extends Command> commandClass) {
         final String className = commandClass.getSimpleName().replace("Command", "");
         return resolvePath(commandBaseLocation, Introspector.decapitalize(className), commandClass);
     }
 
-    private URI resolveQueryPath(final Class<? extends Query> queryClass) {
+    protected URI resolveQueryPath(final Class<? extends Query> queryClass) {
         final String className = queryClass.getSimpleName().replace("Query", "");
         return resolvePath(queryBaseLocation, Introspector.decapitalize(className), queryClass);
     }

--- a/kasper-client/src/main/java/com/viadeo/kasper/client/KasperClientBuilder.java
+++ b/kasper-client/src/main/java/com/viadeo/kasper/client/KasperClientBuilder.java
@@ -93,7 +93,7 @@ public class KasperClientBuilder {
      * @throws KasperException
      */
     public KasperClientBuilder queryBaseLocation(final String url) {
-        return queryBaseLocation(createURL(checkNotNull(url)));
+        return queryBaseLocation(createURL(getCanonicalUrl(url)));
     }
 
     /**
@@ -102,7 +102,18 @@ public class KasperClientBuilder {
      * @throws KasperException
      */
     public KasperClientBuilder commandBaseLocation(final String url) {
-        return commandBaseLocation(createURL(checkNotNull(url)));
+        return commandBaseLocation(createURL(getCanonicalUrl(url)));
+    }
+
+    /**
+     * Add a trailing "/" at the end of the base URL.
+     * Also check url is not null as a precondition
+     * In case of URL without trailing "/", the last part of it is removed by java.net.URL constructor otherwise
+     * @param url
+     * @return url plus trailing "/"
+     */
+    private String getCanonicalUrl(String url) {
+        return checkNotNull(url).endsWith("/") ? url : url + "/";
     }
 
     /**

--- a/kasper-client/src/test/java/com/viadeo/kasper/client/KasperClientBuilderTest.java
+++ b/kasper-client/src/test/java/com/viadeo/kasper/client/KasperClientBuilderTest.java
@@ -7,10 +7,14 @@
 package com.viadeo.kasper.client;
 
 import com.google.common.reflect.TypeToken;
+import com.sun.jersey.api.client.WebResource;
+import com.viadeo.kasper.cqrs.command.Command;
+import com.viadeo.kasper.cqrs.query.Query;
 import com.viadeo.kasper.query.exposition.TypeAdapter;
 import com.viadeo.kasper.query.exposition.adapters.NullSafeTypeAdapter;
 import com.viadeo.kasper.query.exposition.query.QueryBuilder;
 import com.viadeo.kasper.query.exposition.query.QueryParser;
+import junit.framework.Assert;
 import org.junit.Test;
 
 import java.util.Date;
@@ -40,4 +44,54 @@ public class KasperClientBuilderTest {
         assertEquals(expected, ((NullSafeTypeAdapter<Date>) actual).unwrap());
     }
 
+    @Test public void queryBaseLocation_withBaseUrlWithoutTrailingSlash_shouldAddTrailingSlash() {
+        // given
+        final String baseUrl = "http://localhost:8080/kasper/query";
+
+        // when
+        final KasperClient kasperClient = new KasperClientBuilder().queryBaseLocation(baseUrl).create();
+        final WebResource resource = kasperClient.client.resource(kasperClient.resolveQueryPath(TestQuery.class));
+
+        // then
+        Assert.assertEquals("/kasper/query/test", resource.getURI().getPath());
+    }
+
+    @Test public void commandBaseLocation_withBaseUrlWithoutTrailingSlash_shouldAddTrailingSlash() {
+        // given
+        final String baseUrl = "http://localhost:8080/kasper/command";
+
+        // when
+        final KasperClient kasperClient = new KasperClientBuilder().commandBaseLocation(baseUrl).create();
+        final WebResource resource = kasperClient.client.resource(kasperClient.resolveCommandPath(TestCommand.class));
+
+        // then
+        Assert.assertEquals("/kasper/command/test", resource.getURI().getPath());
+    }
+
+    @Test public void queryBaseLocation_withBaseUrlWithTrailingSlash_shouldNotAddTrailingSlash() {
+        // given
+        final String baseUrl = "http://localhost:8080/kasper/query/";
+
+        // when
+        final KasperClient kasperClient = new KasperClientBuilder().queryBaseLocation(baseUrl).create();
+        final WebResource resource = kasperClient.client.resource(kasperClient.resolveQueryPath(TestQuery.class));
+
+        // then
+        Assert.assertEquals("/kasper/query/test", resource.getURI().getPath());
+    }
+
+    @Test public void commandBaseLocation_withBaseUrlWithTrailingSlash_shouldNotAddTrailingSlash() {
+        // given
+        final String baseUrl = "http://localhost:8080/kasper/command/";
+
+        // when
+        final KasperClient kasperClient = new KasperClientBuilder().commandBaseLocation(baseUrl).create();
+        final WebResource resource = kasperClient.client.resource(kasperClient.resolveCommandPath(TestCommand.class));
+
+        // then
+        Assert.assertEquals("/kasper/command/test", resource.getURI().getPath());
+    }
+
+    class TestQuery implements Query {}
+    class TestCommand implements Command {}
 }


### PR DESCRIPTION
...ing the last item of the path

ex: http://localhost:8080/kasper/query became http://localhost:8080/kasper/myQuery instead of http://localhost:8080/kasper/query/myQuery
