### PR TITLE
bugfix: (kasper-client) when kasper answer != 200, returning error with correct code ins...

### DIFF
--- a/kasper-client/src/test/java/com/viadeo/kasper/client/KasperClientCommandTest.java
+++ b/kasper-client/src/test/java/com/viadeo/kasper/client/KasperClientCommandTest.java
@@ -17,6 +17,7 @@ import com.viadeo.kasper.KasperError;
 import com.viadeo.kasper.cqrs.command.Command;
 import com.viadeo.kasper.cqrs.command.CommandResult;
 import com.viadeo.kasper.cqrs.command.CommandResult.Status;
+import junit.framework.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -213,4 +214,39 @@ public class KasperClientCommandTest extends JerseyTest {
         assertEquals(Status.OK, result.getValue().getStatus());
     }
 
+    @Test
+    public void send_withAnswerNot200_shouldFillErrorsInResult() {
+        // Given
+        final CreateMemberCommand command = new CreateMemberCommand(Status.REFUSED);
+        try {
+            client = new KasperClientBuilder().commandBaseLocation(new URL("http://localhost:" + port + "/404/")).create();
+        } catch (MalformedURLException e) {
+            Assert.fail("Shouldn't fail here");
+        }
+
+        // When
+        final CommandResult result = client.send(command);
+
+        // Then
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getError());
+        Assert.assertEquals("404", result.getError().getCode());
+    }
+
+    @Test
+    public void sendAsync_withAnswerNot200_shouldFillErrorsInResult() throws MalformedURLException, InterruptedException,
+            ExecutionException {
+
+        // Given
+        client = new KasperClientBuilder().commandBaseLocation(new URL("http://localhost:" + port + "/404/")).create();
+        final CreateMemberCommand command = new CreateMemberCommand(Status.ERROR);
+
+        // When
+        final CommandResult result = client.sendAsync(command).get();
+
+        // Then
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getError());
+        Assert.assertEquals("404", result.getError().getCode());
+    }
 }

--- a/kasper-client/src/test/java/com/viadeo/kasper/client/KasperClientQueryTest.java
+++ b/kasper-client/src/test/java/com/viadeo/kasper/client/KasperClientQueryTest.java
@@ -21,6 +21,7 @@ import com.viadeo.kasper.cqrs.query.Query;
 import com.viadeo.kasper.cqrs.query.QueryAnswer;
 import com.viadeo.kasper.cqrs.query.QueryResult;
 import com.viadeo.kasper.tools.ObjectMapperProvider;
+import junit.framework.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -258,5 +259,38 @@ public class KasperClientQueryTest extends JerseyTest {
 
         // Then
         checkRoundTrip(query, result);
+    }
+
+    @Test public void query_withAnswerNot200_shouldFillErrorsInResult() {
+        // Given
+        KasperClient client = null;
+        try {
+            client = new KasperClientBuilder()
+                    .queryBaseLocation(new URL("http://localhost:" + port + "/404/"))
+                    .create();
+        } catch (MalformedURLException e) {
+            Assert.fail("Shouldn't throw exception here");
+        }
+        final GetMemberQuery query = new GetMemberQuery("foo bar", Arrays.asList(1, 2, 3));
+
+        // When
+        final QueryResult<MemberAnswer> result = client.query(query, MemberAnswer.class);
+
+        // Then
+        Assert.assertEquals("404", result.getError().getCode());
+    }
+
+    @Test public void queryAsync_withAnswerNot200_shouldFillErrorsInResult() throws MalformedURLException, InterruptedException, ExecutionException {
+        // Given
+        client = new KasperClientBuilder()
+                .queryBaseLocation(new URL("http://localhost:" + port + "/404/"))
+                .create();
+        final GetMemberQuery query = new GetMemberQuery("foo bar", Arrays.asList(1, 2, 3));
+
+        // When
+        final QueryResult<MemberAnswer> result = client.queryAsync(query, MemberAnswer.class).get();
+
+        // Then
+        Assert.assertEquals("404", result.getError().getCode());
     }
 }


### PR DESCRIPTION
...tead of throwing error because client cannot cast the answer into the expected payload. Useful for error handling (in case of 404, 503, etc.)
