### PR TITLE
Add count to CollectionQueryResult toString

### DIFF
--- a/kasper-api/src/main/java/com/viadeo/kasper/cqrs/query/CollectionQueryResult.java
+++ b/kasper-api/src/main/java/com/viadeo/kasper/cqrs/query/CollectionQueryResult.java
@@ -146,6 +146,7 @@ public abstract class CollectionQueryResult<RES extends QueryResult> implements 
     public String toString() {
         return Objects.toStringHelper(this)
                 .add("list", list)
+                .add("count", getCount())
                 .toString();
     }
 


### PR DESCRIPTION
It's useful most of the time for query results.

Disclaimer: I did not test it.
