### PR TITLE
BeanQueryMapper is now sorting fields from Query

### DIFF
--- a/kasper-common/src/main/java/com/viadeo/kasper/query/exposition/query/BeanQueryMapper.java
+++ b/kasper-common/src/main/java/com/viadeo/kasper/query/exposition/query/BeanQueryMapper.java
@@ -10,9 +10,7 @@ import com.google.common.collect.ImmutableSet;
 import com.viadeo.kasper.cqrs.query.Query;
 import com.viadeo.kasper.query.exposition.TypeAdapter;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 class BeanQueryMapper implements TypeAdapter<Query> {
 
@@ -22,7 +20,7 @@ class BeanQueryMapper implements TypeAdapter<Query> {
     // ------------------------------------------------------------------------
 
     public BeanQueryMapper(final BeanConstructor queryCtr, final Set<PropertyAdapter> adapters) {
-        this.adapters = ImmutableSet.copyOf(adapters);
+        this.adapters = ImmutableSet.copyOf(sortPropertyAdapterSet(adapters));
         this.queryCtr = queryCtr;
     }
 
@@ -68,4 +66,16 @@ class BeanQueryMapper implements TypeAdapter<Query> {
         return (Query) queryInstance;
     }
 
+    private SortedSet<PropertyAdapter> sortPropertyAdapterSet(Set<PropertyAdapter> propertyAdapters) {
+        SortedSet<PropertyAdapter> sorted = new TreeSet<>(new Comparator<PropertyAdapter>() {
+            @Override
+            public int compare(PropertyAdapter o1, PropertyAdapter o2) {
+                return o1.getName().compareTo(o2.getName());
+            }
+        });
+        for (PropertyAdapter propertyAdapter : propertyAdapters) {
+            sorted.add(propertyAdapter);
+        }
+        return sorted;
+    }
 }

--- a/kasper-common/src/test/java/com/viadeo/kasper/query/exposition/QueryBuilderTest.java
+++ b/kasper-common/src/test/java/com/viadeo/kasper/query/exposition/QueryBuilderTest.java
@@ -120,5 +120,4 @@ public class QueryBuilderTest {
         assertEquals(new URI("http://www.google.com/somepath?name=f%C3%A9e&names=foo&names=bar").toASCIIString(),
                 builder.build(new URI("http://www.google.com/somepath")).toASCIIString());
     }
-
 }

--- a/kasper-common/src/test/java/com/viadeo/kasper/query/exposition/TestStdQueryFactory.java
+++ b/kasper-common/src/test/java/com/viadeo/kasper/query/exposition/TestStdQueryFactory.java
@@ -18,6 +18,7 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 
 import java.lang.reflect.Type;
+import java.net.URI;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -131,7 +132,40 @@ public class TestStdQueryFactory {
         }
     }
 
+    @Test
+    public void beanQueryMapper_shouldAlphabeticallySortFields() throws Exception {
+        // Given
+        final QueryBuilder builder = new QueryBuilder();
+        final TypeAdapter<SomeQueryWithUnsortedFields> adapter = new DefaultQueryFactory(
+                new FeatureConfiguration(),
+                ImmutableMap.<Type, TypeAdapter>of(int.class, DefaultTypeAdapters.INT_ADAPTER),
+                ImmutableMap.<Type, BeanAdapter>of(),
+                new ArrayList<TypeAdapterFactory>(),
+                VisibilityFilter.PACKAGE_PUBLIC).create(TypeToken.of(SomeQueryWithUnsortedFields.class));
+
+        // When
+        adapter.adapt(new SomeQueryWithUnsortedFields(), builder);
+
+        // Then
+        // We want to test order is deterministic. Testing 20 times.
+        for (int i = 0; i < 20; ++i) {
+            assertEquals(new URI("http://test.com/test?aaa=2&bbb=1").toASCIIString()
+                    , builder.build(new URI("http://test.com/test")).toASCIIString());
+        }
+    }
+
     // ========================================================================
+
+    public static class SomeQueryWithUnsortedFields implements Query {
+        public int getBbb() { return 1; }
+
+        public void setBbb(final int dummyInt) { }
+
+        public int getAaa() { return 2; }
+
+        public void setAaa(final int dummyInt) { }
+
+    }
 
     private TypeAdapterFactory<Map<String, List<DateTime>>> createTypeAdapterFactory() {
         return new TypeAdapterFactory<Map<String, List<DateTime>>>() {


### PR DESCRIPTION
Allows deterministic query parameters order when constructing URL parameters

Ping @EugenCepoi 
