### PR TITLE
UnitOfWork committed even if the handler returns an error

### DIFF
--- a/kasper-core/src/main/java/com/viadeo/kasper/cqrs/command/CommandHandler.java
+++ b/kasper-core/src/main/java/com/viadeo/kasper/cqrs/command/CommandHandler.java
@@ -106,6 +106,10 @@ public abstract class CommandHandler<C extends Command>
                 }
             }
 
+            if ( ! ret.isOK()) {
+                isError = true;
+            }
+
         } catch (final ConflictingAggregateVersionException e) {
             LOGGER.error("Error command [{}]", commandClass, e);
             isError = true;

--- a/kasper-core/src/test/java/com/viadeo/kasper/cqrs/command/CommandHandlerUTest.java
+++ b/kasper-core/src/test/java/com/viadeo/kasper/cqrs/command/CommandHandlerUTest.java
@@ -1,0 +1,123 @@
+// ============================================================================
+//                 KASPER - Kasper is the treasure keeper
+//    www.viadeo.com - mobile.viadeo.com - api.viadeo.com - dev.viadeo.com
+//
+//           Viadeo Framework for effective CQRS/DDD architecture
+// ============================================================================
+package com.viadeo.kasper.cqrs.command;
+
+import com.codahale.metrics.MetricRegistry;
+import com.viadeo.kasper.CoreReasonCode;
+import com.viadeo.kasper.core.metrics.KasperMetrics;
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.domain.MetaData;
+import org.axonframework.unitofwork.CurrentUnitOfWork;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+public class CommandHandlerUTest {
+
+    private enum ResponseType {
+        OK, REFUSE, ERROR, EXCEPTION
+    }
+
+    private static class TestCommandHandler extends CommandHandler<Command> {
+
+        private final ResponseType responseType;
+
+        public TestCommandHandler(final ResponseType responseType) {
+
+            this.responseType = responseType;
+        }
+
+        @Override
+        public CommandResponse handle(Command command) throws Exception {
+            switch (responseType) {
+                case OK:
+                    return CommandResponse.ok();
+                case REFUSE:
+                    return CommandResponse.refused(CoreReasonCode.UNKNOWN_REASON, "");
+                case ERROR:
+                    return CommandResponse.error(CoreReasonCode.UNKNOWN_REASON, "");
+                case EXCEPTION:
+                    throw new RuntimeException("expected exception for test!");
+            }
+            return null;
+        }
+    }
+
+    private KasperUnitOfWork uow;
+
+    @Before
+    public void init() {
+        KasperMetrics.setMetricRegistry(new MetricRegistry());
+        uow = spy(KasperUnitOfWork.startAndGet());
+        CurrentUnitOfWork.set(uow);
+    }
+
+    @Test
+    public void handle_withOkResponse_shouldCommit() throws Throwable {
+        // Given
+        final TestCommandHandler handler = new TestCommandHandler(ResponseType.OK);
+
+        // When
+        final Object response = handler.handle(createCommandMessage(), uow);
+
+        // Then
+        assertNotNull(response);
+        verifyNoMoreInteractions(uow);
+    }
+
+    @Test
+    public void handle_withRefusedResponse_shouldRollback() throws Throwable {
+        // Given
+        final TestCommandHandler handler = new TestCommandHandler(ResponseType.REFUSE);
+
+        // When
+        final Object response = handler.handle(createCommandMessage(), uow);
+
+        // Then
+        assertNotNull(response);
+        verify(uow).rollback();
+    }
+
+    @Test
+    public void handle_withErroredResponse_shouldRollback() throws Throwable {
+        // Given
+        final TestCommandHandler handler = new TestCommandHandler(ResponseType.ERROR);
+
+        // When
+        final Object response = handler.handle(createCommandMessage(), uow);
+
+        // Then
+        assertNotNull(response);
+        verify(uow).rollback();
+
+    }
+
+    @Test
+    public void handle_withUnexpectedError_shouldRollback() throws Throwable {
+        // Given
+        final TestCommandHandler handler = new TestCommandHandler(ResponseType.EXCEPTION);
+
+        // When
+        try {
+            handler.handle(createCommandMessage(), uow);
+        } catch (RuntimeException e) {
+            // nothing
+        }
+
+        // Then
+        verify(uow).rollback(any(Throwable.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private CommandMessage<Command> createCommandMessage() {
+        final CommandMessage message = mock(CommandMessage.class);
+        when(message.getMetaData()).thenReturn(MetaData.emptyInstance());
+        return message;
+    }
+}


### PR DESCRIPTION
We have a handler where different entities are created in different repositories, for some business reasons, we can't create all the entities and we raise an error with CommandResponse.error and INVALID_INPUT (no exception here). But it appears that the unit of work is still commited, the first entities created before the error are created in database where we except a total rollback of the uow.
