### PR TITLE
[ID transformer] change interface from Collection to Map

### DIFF
--- a/kasper-api/src/main/java/com/viadeo/kasper/api/IDTransformer.java
+++ b/kasper-api/src/main/java/com/viadeo/kasper/api/IDTransformer.java
@@ -1,6 +1,7 @@
 package com.viadeo.kasper.api;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Defines the requirement for an object responsible for "transforming" an <code>ID</code>
@@ -12,9 +13,9 @@ public interface IDTransformer {
      *
      * @param format the targeted format
      * @param ids the list of initial ids
-     * @return a list of transformed ids
+     * @return a map of old => transformed
      */
-    Collection<ID> to(Format format, Collection<ID> ids);
+    Map<ID,ID> to(Format format, Collection<ID> ids);
 
     /**
      * Transform the <code>ID</code>s according to the specified <code>Format</code>
@@ -22,9 +23,9 @@ public interface IDTransformer {
      * @param format the targeted format
      * @param firstId the first id
      * @param restIds the rest of ids
-     * @return a list of transformed ids
+     * @return a map of old => transformed
      */
-    Collection<ID> to(Format format, ID firstId,  ID... restIds);
+    Map<ID,ID> to(Format format, ID firstId,  ID... restIds);
 
     /**
      * Transform the <code>ID</code> according to the specified <code>Format</code>

--- a/kasper-api/src/test/java/com/viadeo/kasper/api/IDUTest.java
+++ b/kasper-api/src/test/java/com/viadeo/kasper/api/IDUTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collection;
+import java.util.Map;
 
 import static com.viadeo.kasper.api.TestFormats.DB_ID;
 import static com.viadeo.kasper.api.TestFormats.UUID;
@@ -69,12 +70,12 @@ public class IDUTest {
 
         givenId.setIDTransformer(new IDTransformer() {
             @Override
-            public Collection<ID> to(Format format, Collection<ID> ids) {
+            public Map<ID,ID> to(Format format, Collection<ID> ids) {
                throw new UnsupportedOperationException();
             }
 
             @Override
-            public Collection<ID> to(Format format, ID firstId, ID... restIds) {
+            public Map<ID,ID> to(Format format, ID firstId, ID... restIds) {
                 throw new UnsupportedOperationException();
             }
 


### PR DESCRIPTION
Because it makes no sens to return a list

All implementation of converters already return a Map<ID, ID> in platform
