### PR TITLE
[exposer] Better logs in case of deserialization error

### DIFF
--- a/kasper-exposition/build.gradle
+++ b/kasper-exposition/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     testCompile libraries.GLASSFISH_EXPR_LANG
     testCompile libraries.HIBERNATE_VALIDATOR
     testCompile libraries.TYPESAFE_CONFIG
+    testCompile libraries.SPRING_TEST
 }

--- a/kasper-exposition/src/main/java/com/viadeo/kasper/exposition/http/HttpExposer.java
+++ b/kasper-exposition/src/main/java/com/viadeo/kasper/exposition/http/HttpExposer.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+import com.google.common.io.CharStreams;
 import com.viadeo.kasper.CoreReasonCode;
 import com.viadeo.kasper.KasperResponse;
 import com.viadeo.kasper.annotation.XKasperUnexposed;
@@ -35,6 +36,7 @@ import javax.validation.ConstraintViolation;
 import javax.ws.rs.core.Response;
 import java.beans.Introspector;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.*;
@@ -50,6 +52,7 @@ public abstract class HttpExposer<INPUT, RESPONSE extends KasperResponse> extend
     private static final long serialVersionUID = 8448984922303895424L;
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(HttpExposer.class);
+    protected static final int PAYLOAD_DEBUG_MAX_SIZE = 10000;
 
     private final Map<String, Class<INPUT>> exposedInputs;
     private final Map<String, Class<INPUT>> unexposedInputs;
@@ -88,7 +91,7 @@ public abstract class HttpExposer<INPUT, RESPONSE extends KasperResponse> extend
     // ------------------------------------------------------------------------
 
     protected void checkMediaType(final HttpServletRequest httpRequest) throws HttpExposerException {
-        // nothing
+        // nothing by default
     }
 
     public final void handleRequest(
@@ -105,6 +108,7 @@ public abstract class HttpExposer<INPUT, RESPONSE extends KasperResponse> extend
         final Timer.Context timer = getMetricRegistry().timer(metricNames.getRequestsTimeName()).time();
         final UUID kasperCorrelationUUID = UUID.randomUUID();
 
+        final String payload = getPayloadAsString(httpRequest);
         try {
             MDC.clear();
             MDC.put(Context.REQUEST_CID_SHORTNAME, extractRequestCorrelationId(httpRequest));
@@ -117,7 +121,7 @@ public abstract class HttpExposer<INPUT, RESPONSE extends KasperResponse> extend
             final Context context = extractContext(httpRequest, kasperCorrelationUUID);
 
             /* 3) Extract the input from request */
-            input = extractInput(httpRequest, requestToObject);
+            input = extractInput(httpRequest, payload, requestToObject);
 
             enrichContextAndMDC(context, "appRoute", input.getClass().getName());
 
@@ -216,24 +220,29 @@ public abstract class HttpExposer<INPUT, RESPONSE extends KasperResponse> extend
 
                 sendError(httpResponse, objectToHttpResponse, response, kasperCorrelationUUID);
 
+                final String truncatedPayload = payload.substring(0, Math.min(payload.length(), PAYLOAD_DEBUG_MAX_SIZE));
+
                 if (errorHandlingDescriptor.getState() == ErrorState.REFUSED) {
-                    requestLogger.warn("Refused {} [{}] : <reason={}> <input={}>",
-                            getInputTypeName(), inputName, response.getReason(), input,
+                    requestLogger.warn("Refused {} [{}] : <reason={}> <payload={}>",
+                            getInputTypeName(), inputName, response.getReason(), truncatedPayload,
                             errorHandlingDescriptor.getThrowable()
                     );
                 } else {
-                    requestLogger.error("Error in {} [{}] : <reason={}> <input={}>",
-                            getInputTypeName(), inputName, response.getReason(), input,
+                    requestLogger.error("Error in {} [{}] : <reason={}> <payload={}>",
+                            getInputTypeName(), inputName, response.getReason(), truncatedPayload,
                             errorHandlingDescriptor.getThrowable()
                     );
                 }
-
             } else {
                 requestLogger.debug("Request processed in {} [{}]", getInputTypeName(), inputName);
             }
         } finally {
             MDC.clear();
         }
+    }
+
+    protected String getPayloadAsString(HttpServletRequest httpRequest) throws IOException {
+        return CharStreams.toString(new InputStreamReader(httpRequest.getInputStream()));
     }
 
     public final RESPONSE handle(final INPUT input, final Context context) throws Exception {
@@ -302,6 +311,7 @@ public abstract class HttpExposer<INPUT, RESPONSE extends KasperResponse> extend
 
     protected INPUT extractInput(
             final HttpServletRequest httpRequest,
+            final String payload,
             final HttpServletRequestToObject httpRequestToObject
     ) throws HttpExposerException, IOException {
         long startMillis = System.currentTimeMillis();
@@ -324,11 +334,10 @@ public abstract class HttpExposer<INPUT, RESPONSE extends KasperResponse> extend
 
             /* 4) Extract to a known input */
             try {
-                return httpRequestToObject.map(httpRequest, inputClass);
+                return httpRequestToObject.map(httpRequest, payload, inputClass);
             } catch (Throwable t) {
-                throw new RuntimeException(String.format("Failed to extract input : %s (reason: %s)", requestName, t.getMessage()), t);
+                throw new RuntimeException(String.format("Failed to deserialize payload : %s (reason: %s)", requestName, t.getMessage()), t);
             }
-
         } finally {
             long durationMillis = System.currentTimeMillis() - startMillis;
             MDC.put("durationExtractInput", String.valueOf(durationMillis));

--- a/kasper-exposition/src/main/java/com/viadeo/kasper/exposition/http/HttpQueryExposer.java
+++ b/kasper-exposition/src/main/java/com/viadeo/kasper/exposition/http/HttpQueryExposer.java
@@ -103,6 +103,7 @@ public class HttpQueryExposer extends HttpExposer<Query, QueryResponse> {
         handleRequest(httpRequestToObjectWithString, objectToHttpResponse, req, resp);
     }
 
+    @Override
     protected void checkMediaType(final HttpServletRequest httpRequest) throws HttpExposerException {
         if( "POST".equals(httpRequest.getMethod()) ){
             if( null == httpRequest.getContentType() || ! httpRequest.getContentType().contains(MediaType.APPLICATION_JSON_VALUE) ){

--- a/kasper-exposition/src/main/java/com/viadeo/kasper/exposition/http/HttpServletRequestToObject.java
+++ b/kasper-exposition/src/main/java/com/viadeo/kasper/exposition/http/HttpServletRequestToObject.java
@@ -33,7 +33,11 @@ public abstract class HttpServletRequestToObject {
 
     // ------------------------------------------------------------------------
 
-    public abstract <T> T map(final HttpServletRequest request, final Class<T> clazz) throws Exception;
+    public abstract <T> T map(
+            final HttpServletRequest request
+            , final String payload
+            , final Class<T> clazz
+    ) throws Exception;
 
     public static class StringRequestToObjectMapper extends HttpServletRequestToObject {
 
@@ -45,7 +49,7 @@ public abstract class HttpServletRequestToObject {
         }
 
         @Override
-        public <T> T map(final HttpServletRequest request, final Class<T> clazz) throws IOException {
+        public <T> T map(final HttpServletRequest request, final String payload, final Class<T> clazz) throws IOException {
             final ImmutableSetMultimap.Builder<String, String> params = new ImmutableSetMultimap.Builder<>();
             final Enumeration<String> keys = request.getParameterNames();
 
@@ -75,12 +79,11 @@ public abstract class HttpServletRequestToObject {
             super(objectMapper);
         }
 
-        public <T> T map(final HttpServletRequest request, final Class<T> clazz) throws Exception {
-            String json = CharStreams.toString(new InputStreamReader(request.getInputStream()));
-            if (json == null || json.trim().length() == 0) {
+        public <T> T map(final HttpServletRequest request, final String payload, final Class<T> clazz) throws Exception {
+            if (payload == null || payload.trim().length() == 0) {
                 return clazz.newInstance();
             }
-            try (final JsonParser parser = reader.getFactory().createParser(json)) {
+            try (final JsonParser parser = reader.getFactory().createParser(payload)) {
                 return reader.readValue(parser, clazz);
             }
         }

--- a/kasper-exposition/src/test/java/com/viadeo/kasper/exposition/http/HttpExposerUTest.java
+++ b/kasper-exposition/src/test/java/com/viadeo/kasper/exposition/http/HttpExposerUTest.java
@@ -5,15 +5,30 @@ import com.viadeo.kasper.KasperReason;
 import com.viadeo.kasper.KasperResponse;
 import com.viadeo.kasper.client.platform.Meta;
 import com.viadeo.kasper.context.Context;
+import org.eclipse.jetty.io.bio.StringEndPoint;
+import org.eclipse.jetty.server.BlockingHttpConnection;
+import org.eclipse.jetty.server.HttpInput;
+import org.eclipse.jetty.server.Server;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
 
+import javax.servlet.*;
+import javax.servlet.http.*;
 import javax.ws.rs.core.Response;
-import java.util.List;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class HttpExposerUTest {
 
@@ -136,6 +151,38 @@ public class HttpExposerUTest {
         // Then
         assertNotNull(status);
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR, status);
+    }
+
+    @Test
+    public void getPayloadAsString_shouldReturnRequestBodyAsString() throws IOException {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("POST");
+        request.setContentType("application/json");
+        String body = "{\"test\":\"toto\"}";
+        request.setContent(body.getBytes());
+
+        // when
+        String objectToLogForDebug = exposer.getPayloadAsString(request);
+
+        // then
+        assertEquals(body, objectToLogForDebug);
+    }
+
+    @Test
+    public void getPayloadAsString_whenNoContent_shouldReturnEmptyString() throws IOException {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("POST");
+        request.setContentType("application/json");
+        String body = "";
+        request.setContent(body.getBytes());
+
+        // when
+        String objectToLogForDebug = exposer.getPayloadAsString(request);
+
+        // then
+        assertEquals("", objectToLogForDebug);
     }
 
     private static KasperResponse createKasperResponse(KasperResponse.Status status) {

--- a/kasper-exposition/src/test/java/com/viadeo/kasper/exposition/http/HttpServletRequestToObjectUTest.java
+++ b/kasper-exposition/src/test/java/com/viadeo/kasper/exposition/http/HttpServletRequestToObjectUTest.java
@@ -24,6 +24,7 @@ public class HttpServletRequestToObjectUTest {
 
     private HttpServletRequestToObject.JsonToObjectMapper mapper;
     private HttpServletRequest request;
+    private String payload;
 
     @Before
     public void setUp() throws Exception {
@@ -35,12 +36,13 @@ public class HttpServletRequestToObjectUTest {
                 return -1;
             }
         });
+        payload = "";
     }
 
     @Test
     public void map_withJsonToObjectMapper_withEmptyInput_forQueryWithoutParameters_isOk() throws Exception {
         // When
-        TestQuery query = mapper.map(request, TestQuery.class);
+        TestQuery query = mapper.map(request, payload, TestQuery.class);
 
         // Then
         Assert.assertNotNull(query);
@@ -48,6 +50,6 @@ public class HttpServletRequestToObjectUTest {
 
     @Test(expected = InstantiationException.class)
     public void map_withJsonToObjectMapper_withEmptyInput_forQueryWithParameters_isKo() throws Exception {
-        mapper.map(request, TestQueryWithParameters.class);
+        mapper.map(request, payload, TestQueryWithParameters.class);
     }
 }


### PR DESCRIPTION
The idea is to have 

`{"message":"Failed to deserialize payload : getPreferredSkillCompletion (reason: Can not deserialize instance of java.util.ArrayList out of VALUE_STRING token)"}`
instead of 
`{"message":"Failed to extract input : getPreferredSkillCompletion"}`

and 

`Error in Query [getPreferredSkillCompletion] : <reason=KasperReason{a08003fd-b480-479c-8754-2fc87a290cae, UNKNOWN_REASON, [Failed to extract input : getPreferredSkillCompletion]}> <input={"theContentOf": "the payload"}>`
instead of 
`Error in Query [undefined] : <reason=KasperReason{a08003fd-b480-479c-8754-2fc87a290cae, UNKNOWN_REASON, [Failed to extract input : getPreferredSkillCompletion]}> <input=null>`

ping @dstendardi @VanNayer @cmurer @mglcel 
