### PR TITLE
[tags interceptor] Restore MDC context map after execution of next handler in chain

### DIFF
--- a/kasper-core/src/main/java/com/viadeo/kasper/cqrs/command/impl/KasperCommandGateway.java
+++ b/kasper-core/src/main/java/com/viadeo/kasper/cqrs/command/impl/KasperCommandGateway.java
@@ -6,10 +6,8 @@
 // ============================================================================
 package com.viadeo.kasper.cqrs.command.impl;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.viadeo.kasper.context.Context;
-import com.viadeo.kasper.context.Contexts;
 import com.viadeo.kasper.core.context.CurrentContext;
 import com.viadeo.kasper.core.interceptor.InterceptorChainRegistry;
 import com.viadeo.kasper.core.interceptor.InterceptorFactory;
@@ -22,7 +20,6 @@ import com.viadeo.kasper.cqrs.command.CommandHandler;
 import com.viadeo.kasper.cqrs.command.CommandResponse;
 import com.viadeo.kasper.cqrs.command.interceptor.CommandHandlerInterceptorFactory;
 import com.viadeo.kasper.cqrs.command.interceptor.KasperCommandInterceptor;
-import com.viadeo.kasper.context.MDCUtils;
 import com.viadeo.kasper.exception.KasperException;
 import org.axonframework.commandhandling.CommandDispatchInterceptor;
 import org.axonframework.commandhandling.CommandHandlerInterceptor;
@@ -236,18 +233,6 @@ public class KasperCommandGateway implements CommandGateway {
                 command,
                 context
         );
-    }
-
-    @VisibleForTesting
-    protected Context enrichContextAndMdcContextMap(final Command command, final Context context) {
-        checkNotNull(command);
-        checkNotNull(context);
-
-        Context newContext = Contexts.newFrom(context).build();
-
-        MDCUtils.enrichMdcContextMap(newContext);
-
-        return newContext;
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
ping @cmurer 

Description of bug:

A Command/Query handler has a tag / several tags. The handler gets called inside another handler / inside an event listener. The tag(s) stay in the MDC context map after the call, so if an exception is raised by the calling handler / listener, the error will be searchable in Kibana under the callee handler tags.

This commit snapshots the MDC context map in the TagsInterceptor, before adding the targeted handler tags, and restore the MDC context map to its original state after the call to the next element in the chain completes.
