### PR TITLE
Get rid of `Call actor chain for *` INFO logs

### DIFF
--- a/kasper-core/src/main/java/com/viadeo/kasper/core/component/event/eventbus/KasperEventBus.java
+++ b/kasper-core/src/main/java/com/viadeo/kasper/core/component/event/eventbus/KasperEventBus.java
@@ -286,7 +286,6 @@ public class KasperEventBus extends ClusteringEventBus {
         checkNotNull(event);
         final Optional<InterceptorChain<Event, Void>> optionalRequestChain = getInterceptorChain(event.getClass());
         try {
-            LOGGER.info("Call actor chain for Event " + event.getClass().getSimpleName());
             optionalRequestChain.get().next(event, context);
         } catch (final RuntimeException e) {
             LOGGER.error("Failed to publish event, <event={}> <context={}>", event, context, e);

--- a/kasper-core/src/main/java/com/viadeo/kasper/core/component/query/gateway/KasperQueryBus.java
+++ b/kasper-core/src/main/java/com/viadeo/kasper/core/component/query/gateway/KasperQueryBus.java
@@ -96,7 +96,6 @@ public class KasperQueryBus {
             }
 
             try {
-                LOGGER.info("Call actor chain for query " + queryClass.getSimpleName());
                 @SuppressWarnings("unchecked")
                 R ret = (R) optionalRequestChain.get().next(query, context);
                 callback.onSuccess(ret);


### PR DESCRIPTION
These logs seem useless and we spam the log system with them ; we had 11812840 in the last 2 days, 12 millions ! That's 68 per second, 1 every 15 milliseconds !

To put that into perspective, we have 17206421 log items in Kibana right now for the last two days, so these useless logs represent 69% of the kviadeo-web logs on Kibana...
